### PR TITLE
improve turning behaviour of rover

### DIFF
--- a/models/basic_rover/model.sdf
+++ b/models/basic_rover/model.sdf
@@ -78,8 +78,10 @@
           <surface>
             <friction>
               <ode>
-                <mu>0.05</mu>
-                <mu2>0.05</mu2>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.2</slip1>
+                <slip2>0.2</slip2>
               </ode>
             </friction>
           </surface>
@@ -151,8 +153,10 @@
           <surface>
             <friction>
               <ode>
-                <mu>0.05</mu>
-                <mu2>0.05</mu2>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.2</slip1>
+                <slip2>0.2</slip2>
               </ode>
             </friction>
           </surface>
@@ -224,8 +228,10 @@
           <surface>
             <friction>
               <ode>
-                <mu>0.05</mu>
-                <mu2>0.05</mu2>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.2</slip1>
+                <slip2>0.2</slip2>
               </ode>
             </friction>
           </surface>
@@ -289,8 +295,10 @@
           <surface>
             <friction>
               <ode>
-                <mu>0.05</mu>
-                <mu2>0.05</mu2>
+                <mu>1</mu>
+                <mu2>1</mu2>
+                <slip1>0.2</slip1>
+                <slip2>0.2</slip2>
               </ode>
             </friction>
           </surface>


### PR DESCRIPTION
Fixes issues with turning, the rover was getting stuck at the plane axes similar to this [issue](https://answers.ros.org/question/246914/four-wheeled-skid-steering-in-gazebo-and-ros-using-gazebo-ros-control/). I also referred to answers in [here](http://answers.gazebosim.org/question/1505/how-do-i-set-up-mu-and-slip-for-a-skid-steer-robot/). 