### PR TITLE
fix dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,124 +1,36 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(autonomous_sim)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-# add_compile_options(-std=c++11)
-
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   gazebo_ros
   message_generation
+  common
 )
 
 # Depend on system install of Gazebo
 find_package(gazebo REQUIRED)
 
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
 ## Generate messages in the 'msg' folder
 add_message_files(
   FILES
-  DriveCmd.msg
   EncoderData.msg
 )
 
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
 ## Generate added messages and services with any dependencies listed here
- generate_messages(
-   DEPENDENCIES
-   std_msgs
- )
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+)
 
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   DEPENDS
     roscpp
     gazebo_ros
   INCLUDE_DIRS 
     include
-#  LIBRARIES autonomous_sim
   CATKIN_DEPENDS roscpp rospy std_msgs message_runtime
-#  DEPENDS system_lib
 )
-
-###########
-## Build ##
-###########
 
 link_directories(${GAZEBO_LIBRARY_DIRS})
 
@@ -126,84 +38,10 @@ link_directories(${GAZEBO_LIBRARY_DIRS})
 ## Your package locations should be listed before other locations
 include_directories(${Boost_INCLUDE_DIR} ${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} include/autonomous_sim)
 
-
 ## Declare a C++ library
 add_library(gazebo_ros_skid_steer_drive_custom src/gazebo_ros_skid_steer_drive_custom.cpp)
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-# add_executable(${PROJECT_NAME}_node src/autonomous_sim_node.cpp)
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(gazebo_ros_skid_steer_drive_custom ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
 
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
-# install(TARGETS ${PROJECT_NAME}_node
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark libraries for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
-# install(TARGETS ${PROJECT_NAME}
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_autonomous_sim.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+add_dependencies(gazebo_ros_skid_steer_drive_custom autonomous_sim_gencpp)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Everything runs on Ubuntu 18.04 LTS
   * `$ sudo apt-get install ros-melodic-gazebo-ros-pkgs ros-melodic-gazebo-ros-control`
   * `$ sudo apt-get install ros-melodic-hector-gazebo-plugins`
   * `$ sudo apt-get install ros-melodic-rqt-robot-steering` - pkg for steering rover via a gui
+* Depends on messages defined in common repo https://github.com/novarover/common, please clone into same workspace.
   
  ## Git Usage:
  * Clone this repository into a subdirectory of the catkin workspace src folder.

--- a/include/autonomous_sim/gazebo_ros_skid_steer_drive_custom.h
+++ b/include/autonomous_sim/gazebo_ros_skid_steer_drive_custom.h
@@ -41,15 +41,13 @@
 
 #include <map>
 
-#include <gazebo/common/common.hh>
-#include <gazebo/physics/physics.hh>
-
 // ROS
 #include <ros/ros.h>
 #include <tf/transform_broadcaster.h>
 #include <tf/transform_listener.h>
 #include <geometry_msgs/Twist.h>
-#include <autonomous_sim/DriveCmd.h>
+#include <common/DriveCmd.h>
+namespace common_rover = common;
 #include <autonomous_sim/EncoderData.h>
 #include <nav_msgs/Odometry.h>
 #include <nav_msgs/OccupancyGrid.h>
@@ -61,6 +59,11 @@
 // Boost
 #include <boost/thread.hpp>
 #include <boost/bind.hpp>
+
+
+#include <gazebo/common/common.hh>
+#include <gazebo/physics/physics.hh>
+
 
 namespace gazebo {
 
@@ -127,7 +130,7 @@ namespace gazebo {
 
       // DiffDrive stuff
       void cmdVelCallback(const geometry_msgs::Twist::ConstPtr& cmd_msg);
-      void driveCmdCallback(const autonomous_sim::DriveCmd::ConstPtr& msg);
+      void driveCmdCallback(const common_rover::DriveCmd::ConstPtr& msg);
       double x_;
       double rot_;
       bool alive_;

--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,7 @@
     <depend>rospy</depend>
     <depend>std_msgs</depend>
     <depend>gazebo_ros</depend>
+    <depend>common</depend>
     
   <!--   Note that this is equivalent to the following: -->
   <!--   <build_depend>roscpp</build_depend> -->

--- a/src/gazebo_ros_skid_steer_drive_custom.cpp
+++ b/src/gazebo_ros_skid_steer_drive_custom.cpp
@@ -338,7 +338,7 @@ namespace gazebo {
     
     // ROS: Subscribe to the custom DriveCmd.msg drive topic (usuall "gazebo/driver/drive_cmd")
     ros::SubscribeOptions so_drive_cmd =
-      ros::SubscribeOptions::create<autonomous_sim::DriveCmd>(drive_cmd_topic_, 1,
+      ros::SubscribeOptions::create<common_rover::DriveCmd>(drive_cmd_topic_, 1,
           boost::bind(&GazeboRosSkidSteerDriveCustom::driveCmdCallback, this, _1),
           ros::VoidPtr(), &queue_);
 
@@ -417,7 +417,7 @@ namespace gazebo {
   }
 
   void GazeboRosSkidSteerDriveCustom::driveCmdCallback(
-      const autonomous_sim::DriveCmd::ConstPtr& msg) {
+      const common_rover::DriveCmd::ConstPtr& msg) {
         
     // convert DriveCmd to Twist
     geometry_msgs::Twist* twist = new geometry_msgs::Twist();


### PR DESCRIPTION
cleaned up the CMakeList, all the comments were too distracting
build error was due to missing line:
`add_dependencies(gazebo_ros_skid_steer_drive_custom autonomous_sim_gencpp)`

now uses DriveCmd message from common repo instead of duplicating the definition

namespace alias was required due to another namespace with the name `common`
`namespace common_rover = common;`